### PR TITLE
Get around Devin's discovered issue with double-quotes in code block in hints

### DIFF
--- a/04-oop/classes-in-ruby.md
+++ b/04-oop/classes-in-ruby.md
@@ -122,7 +122,10 @@ end
 ```ruby
 class Product
   def name
-    return "Dr. Donnie's cure-all tonic"
+      # note Learn seems to have issues with double quotes here
+      #  So I used single quotes to get around it.
+      #  In Ruby you can use double quotes
+    return 'Dr. Donnie\'s cure-all tonic'
   end
 
   # More methods here


### PR DESCRIPTION
The bug only seems to affect code blocks in learn with single and double quotes together in the same string... weird.  I guess you shouldn't have code in the hints. 